### PR TITLE
Updated code of conduct link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can install Ballerina by following the Ballerina [installation guide](https:
 
 Thank you so much for contributing! :tada:
 
-Please read about how to [get involved in a track](https://github.com/exercism/docs/tree/master/contributing-to-language-tracks). Be sure to read the Exercism [Code of Conduct](https://github.com/exercism/exercism.io/blob/master/CODE_OF_CONDUCT.md).
+Please read about how to [get involved in a track](https://github.com/exercism/docs/tree/master/contributing-to-language-tracks). Be sure to read the Exercism [Code of Conduct](https://exercism.io/code-of-conduct).
 
 We welcome pull requests of all kinds. No contribution is too small.
 


### PR DESCRIPTION
Issue #4441

I updated the link in the README file for the code of Conduct to https://exercism.io/code-of-conduct. The link no longer leads to a 404 error.