### PR TITLE
Mark maintainers as active in config

### DIFF
--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -3,7 +3,6 @@
   "maintainers": [
     {
       "github_username": "kasun04",
-      "alumnus": true,
       "show_on_website": false,
       "name": null,
       "link_text": null,
@@ -13,7 +12,6 @@
     },
     {
       "github_username": "lafernando",
-      "alumnus": true,
       "show_on_website": false,
       "name": null,
       "link_text": null,
@@ -23,7 +21,6 @@
     },
     {
       "github_username": "vinok88",
-      "alumnus": true,
       "show_on_website": false,
       "name": null,
       "link_text": null,
@@ -33,7 +30,6 @@
     },
     {
       "github_username": "ldclakmal",
-      "alumnus": true,
       "show_on_website": false,
       "name": null,
       "link_text": null,
@@ -43,7 +39,6 @@
     },
     {
       "github_username": "Manuri",
-      "alumnus": true,
       "show_on_website": false,
       "name": null,
       "link_text": null,
@@ -53,7 +48,6 @@
     },
     {
       "github_username": "MaryamZi",
-      "alumnus": true,
       "show_on_website": false,
       "name": null,
       "link_text": null,
@@ -63,7 +57,6 @@
     },
     {
       "github_username": "keizer619",
-      "alumnus": true,
       "show_on_website": false,
       "name": null,
       "link_text": null,


### PR DESCRIPTION
The maintainers are not alumni, but since they are marked as such
the maintainer bot removed them all from the team.

FYI @kasun04 