### PR TITLE
Make track inactive

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "track_id": "ballerina",
   "language": "Ballerina",
-  "active": true,
+  "active": false,
   "blurb": "Ballerina is a cloud-native programming language that incorporates fundamental concepts of distributed system integration into the language and offers a type safe, concurrent environment to implement microservices with distributed transactions, reliable messaging, stream processing, and workflows.",
   "ignore_pattern": "[Ee]xample",
   "solution_pattern": "reference",


### PR DESCRIPTION
In an email discussion, one of the track maintainers indicated that the current Ballerina track is slightly troublesome, as some new students can't get the exercises to work with the latest Ballerina version. As we want to get all tracks to v3, there won't be any resources left to work on fixing the current issues. Hence, as a temporary solution, we can deactivate the track. We can then reactivate it again when we have a v3 version of the track.