### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/config/exercise-readme-insert.md
+++ b/config/exercise-readme-insert.md
@@ -1,0 +1,2 @@
+# exercise readme insert
+

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 [Ballerina](https://ballerina.io/) is a compiled, transactional, statically and strongly typed programming language with textual and graphical syntaxes. Ballerina incorporates fundamental concepts of distributed system integration into the language and offers a type-safe, concurrent environment to implement microservices with distributed transactions, reliable messaging, stream processing, and workflows. 
 
 Ballerina is a language designed to be integration simple. Based around the interactions of sequence diagrams, Ballerina has built-in support for common integration patterns and connectors, including distributed transactions, compensation and circuit breakers. With first-class support for JSON and XML, Ballerina makes it simple and effective to build robust integration across network endpoints.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,1 +1,3 @@
+# Installation
+
 You can install Ballerina by following the Ballerina [installation guide](https://ballerina.io/learn/installing-ballerina/). 

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,1 +1,3 @@
+# Learning
+
 Ballerina [learn](https://ballerina.io/learn) page contains multiple resources you to get up to speed with the language, master the concepts, and build comprehensive real-world use cases. 

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,0 +1,2 @@
+# Resources
+


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
