### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,25 @@
+{
+  "docs": [
+    {
+      "uuid": "55046ce5-631c-4647-a517-0d74a55fef99",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Ballerina locally",
+      "blurb": "Learn how to install Ballerina locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "d1319abb-3751-408b-b831-88fcf6b36aee",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Ballerina",
+      "blurb": "An overview of how to get started from scratch with Ballerina"
+    },
+    {
+      "uuid": "4a9cc496-ff82-4eb6-bd80-fe6b926ca802",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Ballerina track",
+      "blurb": "Learn how to test your Ballerina exercises on Exercism"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
