### PR TITLE
🤖 Sync exercise files keys based on file path patterns

### DIFF
--- a/exercises/practice/calculator-service/.meta/config.json
+++ b/exercises/practice/calculator-service/.meta/config.json
@@ -1,8 +1,14 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "calculator_service.bal"
+    ],
+    "test": [
+      "tests/calculator_service_test.bal"
+    ],
+    "example": [
+      ".meta/reference/calculator_service.bal"
+    ]
   }
 }

--- a/exercises/practice/echo-service/.meta/config.json
+++ b/exercises/practice/echo-service/.meta/config.json
@@ -1,8 +1,14 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "echo_service.bal"
+    ],
+    "test": [
+      "tests/echo_service_test.bal"
+    ],
+    "example": [
+      ".meta/reference/echo_service.bal"
+    ]
   }
 }

--- a/exercises/practice/greeting-service/.meta/config.json
+++ b/exercises/practice/greeting-service/.meta/config.json
@@ -1,8 +1,14 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "greeting_service.bal"
+    ],
+    "test": [
+      "tests/greeting_service_test.bal"
+    ],
+    "example": [
+      ".meta/reference/greeting_service.bal"
+    ]
   }
 }

--- a/exercises/practice/hello-world-service/.meta/config.json
+++ b/exercises/practice/hello-world-service/.meta/config.json
@@ -1,8 +1,14 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "hello_world_service.bal"
+    ],
+    "test": [
+      "tests/hello_world_service_test.bal"
+    ],
+    "example": [
+      ".meta/reference/hello_world_service.bal"
+    ]
   }
 }

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "hello_world.bal"
+    ],
+    "test": [
+      "tests/hello_world_test.bal"
+    ],
+    "example": [
+      ".meta/reference/hello_world.bal"
+    ]
   },
   "source": "This is an exercise to introduce users to using Exercism",
   "source_url": "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program"

--- a/exercises/practice/legacy-service-client/.meta/config.json
+++ b/exercises/practice/legacy-service-client/.meta/config.json
@@ -1,8 +1,14 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "legacy_service_client.bal"
+    ],
+    "test": [
+      "tests/legacy_service_client_test.bal"
+    ],
+    "example": [
+      ".meta/reference/legacy_service_client.bal"
+    ]
   }
 }

--- a/exercises/practice/order-management/.meta/config.json
+++ b/exercises/practice/order-management/.meta/config.json
@@ -1,8 +1,14 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "order_management.bal"
+    ],
+    "test": [
+      "tests/order_management_test.bal"
+    ],
+    "example": [
+      ".meta/reference/order_management.bal"
+    ]
   }
 }

--- a/exercises/practice/service-composition/.meta/config.json
+++ b/exercises/practice/service-composition/.meta/config.json
@@ -1,8 +1,14 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "service_composition.bal"
+    ],
+    "test": [
+      "tests/service_composition_test.bal"
+    ],
+    "example": [
+      ".meta/reference/service_composition.bal"
+    ]
   }
 }

--- a/exercises/practice/service-invocation/.meta/config.json
+++ b/exercises/practice/service-invocation/.meta/config.json
@@ -1,8 +1,14 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "service_invocation.bal"
+    ],
+    "test": [
+      "tests/service_invocation_test.bal"
+    ],
+    "example": [
+      ".meta/reference/service_invocation.bal"
+    ]
   }
 }


### PR DESCRIPTION
To help tracks define the files in the exercise's `.meta/config.json` file, we've added support for defining these file patterns in the track's `config.json` file. See [this PR](https://github.com/exercism/docs/pull/58).

This PR updates the file paths defined in the `files` property of each exercise's `.meta/config.json` file according to the file patterns defined in the track's `config.json` file.

We only update a file path in the `.meta/config.json` file if:

- The file path pattern is a non-empty array in the `config.json` file
- The file path pattern is either not set or an empty array in the `.meta/config.json` file

This means that exercises that had already defined files in the `.meta/config.json` won't be touched in this PR.

Note that this PR is just an easy way for tracks to populate the files in the `.meta/config.json` files. Tracks are completely free to add/change/remove the files in their `.meta/config.json` files.

In the future, we'll update `configlet` to include this functionality. If you'd like me to re-run the script because changes have been made, feel free to ping me on Slack (@erikschierboom).

## Tracking

https://github.com/exercism/v3-launch/issues/20

