### PR TITLE
Capitalize scrabble-score exercise name

### DIFF
--- a/config.json
+++ b/config.json
@@ -572,7 +572,7 @@
       },
       {
         "slug": "scrabble-score",
-        "name": "scrabble score",
+        "name": "Scrabble Score",
         "uuid": "a2551202-8959-43c9-aa83-8ae38db43bec",
         "practices": [],
         "prerequisites": [],


### PR DESCRIPTION
The other exercise names are titlecased so this is a quick fix for consistency