### PR TITLE
 Do not convert `average_run_time` to float 

### DIFF
--- a/bin/add-exercise
+++ b/bin/add-exercise
@@ -41,7 +41,7 @@ uuid=$(bin/configlet uuid)
 jq --arg slug "${slug}" --arg uuid "${uuid}" --arg name "${name}" \
     '.exercises.practice += [{slug: $slug, name: $name, uuid: $uuid, practices: [], prerequisites: [], difficulty: 1}]' \
     config.json \
-| sed 's/"average_run_time": 10/&.0/' > config.json.tmp \
+> config.json.tmp \
 && mv config.json.tmp config.json
 
 pushd exercises/practice


### PR DESCRIPTION
See https://github.com/exercism/configlet/pull/765 for context, but `average_run_time` should be an integer as it is currently, not a float. Otherwise, configlet will complain while generating a new exercise.