### PR TITLE
fix: update macOs workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12]
+        os: [ubuntu-22.04, macos-14]
         java-version: [11]
         ballerina-version: [2201.5.0]
 


### PR DESCRIPTION
GitHub dropped macOS-12 support. Workflow needs updating to 14.

See: https://forum.exercism.org/t/github-actions-runner-breaking-changes-announced/12612